### PR TITLE
Version selection strategy (our/their/prompt) + performance and misc cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,24 @@
 POMUtils
 =============
 
-This library is for making the day easier while using git and maven. If you do almost weekly or daily releases you get in trouble with merge conflicts regarding to the parent and/or project version of your pom.xml Files. In a big project this is a real pain.
+This library is for making the day easier while using git and maven.
+If you do almost weekly or daily releases you get in trouble with merge
+conflicts regarding to the parent and/or project version of your pom.xml files.
+In a project with many child modules this is a real pain.
 
-There are some tools out there which also try to accomplish this goal, but IMO they don't do it in the right way. Some are doing a search and replace of `<version>...</version>` and they don't make sure that only the parent and project version has changed. Some others are using a DOM Parser, adjusting the versions via xpath and save it. That way you get a new formatted xml file. What you also don't want.
+There are some tools out there which also try to accomplish this goal,
+but IMO they don't do it in the right way. Some are doing a search and
+replace of `<version>...</version>` and they don't make sure that only
+the parent and project version has changed. Some others are using a DOM Parser,
+adjusting the versions via xpath and save it.
+That way you get a new formatted xml file. What you also don't want.
 
-Here you find a library which solves this problem, imo, in the right way ;-). It just adjust the parent and/or project version. Nothing else. Internally it uses classes of the versions-maven-plugin, that why it is a java program. There is only one downside. It's slow. Because git start's for every single pom merge a new VM. For ~100 pom.xml files it takes around 20 Seconds to merge them.
+Here you find a library which solves this problem, imo, in the right way ;-).
+It just adjusts the parent and/or project version. Nothing else.
+Internally it uses classes of the `versions-maven-plugin`,
+that why it is a java program.
+There is only one downside. It's slow, because git starts a new JVM for every pom file merge.
+For ~100 pom.xml files it takes around 20 seconds to merge them.
 
 
 Installation
@@ -19,23 +32,29 @@ For usage, call: `java -jar pomutils-X.X.jar --help`
 ```
 java -jar target/pomutils-1.0.jar --help
 Usage: <main class> [options] [command] [command options]
-Options:
-       --debug
+  Options:
+        --debug
        If you want to print debug information add this option.
        Default: false
-       --help
+        --help
        Used to print this information.
        Default: false
   Commands:
-    merge      Used as merge driver in git. Updates the version of 'their pom.xml' with the version from 'our pom.xml' and does finally a normal 'git merge-file'
+    merge      Used as merge driver in git.  Updates the version of 'our' pom or 'their' pom (based on the value of --select), and then does a normal 'git merge-file'
       Usage: merge [options]
         Options:
         * -b, --base
              Base Pom
         * -o, --our
              Our Pom
+          -s, --select
+             Which version to select to resolve conflicts.  'our', 'their', or
+             'prompt'.  If 'prompt' is specified, then you will be prompted on the console
+             to select a version.
+             Default: our
         * -t, --their
              Their Pom
+
     replace      Updates the parent version and/or the project version in the given pom.xml
       Usage: replace [options]
         Options:
@@ -43,27 +62,44 @@ Options:
              The pom where you want to replace the parent and project version
         * -v, --version
              The new version you want to set
+
 ```
 
 *merge* Command Usage
 ------------
 This command is used as pom merge driver in git. To configure it you have to do the following:
 
-1. In your git project edit the .gitattributes file (or create it if it doesn't exist) and add the following line:
-    `pom.xml merge=pomMergeDriver`
-2. In your .git/config you have to define how the *pomMergeDriver* should be called. Add the following lines:
+1. In your git project, edit the `.gitattributes` file (or create it if it doesn't exist) and add the following line:
+
+    ```
+    pom.xml merge=pom
+    ```
+
+2. In your `.git/config`, you have to define how the `pom` merge driver should be called. Add the following lines:
+
 	```
-	[merge "pomMergeDriver"]
-		name = Merge pom's using always our strategy for project and/or parent version. The rest a normal merge.
+	[merge "pom"]
+		name = Automatically resolve project and/or parent version conflicts in pom files. The rest is a normal merge.
 		driver = java -jar <pathToJar>/pomutils-X.X.jar merge --base=%O --our=%A --their=%B
 	```
 
-	To speed up the vm start, i use the following line:	
+	To speed up the vm start, I use the following line:	
 	
 	```driver = java -jar -client -Xverify:none -Xms32m -Xmx32m  <pathToJar>/pomutils-X.X.jar merge --base=%O --our=%A --their=%B```
+
 3. Done.
 
-What is this merge driver doing? First, the parent/project version of the *their* pom.xml is adjusted with the one from *our* pom.xml. Then the git command "merge-file" is called, which is the default merge driver.
+By default, project/parent version conflicts will be resolved using *our* version.
+You can change this behaviour by specifying `--select their` or  `--select prompt` on the command line.
+Select `their` to always resolve version conflicts using *their* version.
+Select `prompt` to prompt the user on the console to select a version at merge time.
+Note that you must be performing merges from the command line for `prompt` to work.
+If you use a GUI to perform merge, do not use `--select prompt`, unless the GUI provides
+a way to enter input on the git merge console.
+
+Internally, the merge driver will adjust the parent/project version
+of either *their* pom.xml file or *our* pom.xml file (depending on the value of `--select`),
+then run the `git merge-file` command (which is used by the default merge driver).
 
 
 *replace* Command Usage

--- a/pom.xml
+++ b/pom.xml
@@ -200,7 +200,13 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>3.8.1</version>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>1.10.17</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,78 @@
             <type>maven-plugin</type>
             <exclusions>
                 <exclusion>
+                    <groupId>org.apache.maven</groupId>
+                    <artifactId>maven-artifact-manager</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.maven</groupId>
+                    <artifactId>maven-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.maven</groupId>
+                    <artifactId>maven-plugin-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.maven</groupId>
+                    <artifactId>maven-plugin-registry</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.maven</groupId>
+                    <artifactId>maven-plugin-descriptor</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.maven</groupId>
+                    <artifactId>maven-settings</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.maven.reporting</groupId>
+                    <artifactId>maven-reporting-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.maven.reporting</groupId>
+                    <artifactId>maven-reporting-impl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.maven.shared</groupId>
+                    <artifactId>maven-common-artifact-filters</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.maven.wagon</groupId>
+                    <artifactId>wagon-provider-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.maven.wagon</groupId>
+                    <artifactId>wagon-file</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.maven.doxia</groupId>
+                    <artifactId>doxia-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.maven.doxia</groupId>
+                    <artifactId>doxia-sink-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.maven.doxia</groupId>
+                    <artifactId>doxia-site-renderer</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.plexus</groupId>
+                    <artifactId>plexus-container-default</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.plexus</groupId>
+                    <artifactId>plexus-interactivity-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.plexus</groupId>
+                    <artifactId>plexus-i18n</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.plexus</groupId>
+                    <artifactId>plexus-interpolation</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-nop</artifactId>
                 </exclusion>
@@ -112,6 +184,12 @@
         </dependency>
 
         <!-- test -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>3.8.1</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,19 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.5</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>2.3</version>
                 <executions>

--- a/src/main/java/de/oppermann/pomutils/Main.java
+++ b/src/main/java/de/oppermann/pomutils/Main.java
@@ -61,7 +61,9 @@ public class Main {
 
 		logger = LoggerFactory.getLogger(Main.class);
 
-		logger.info("PomUtils version {}", ManifestUtils.getImplementationVersion());
+		if (logger.isInfoEnabled()) {
+			logger.info("PomUtils version {}", ManifestUtils.getImplementationVersion());
+		}
 
 		if ("merge".equals(jc.getParsedCommand())) {
 			return executePomMergeDriver(mergeCommand);

--- a/src/main/java/de/oppermann/pomutils/Main.java
+++ b/src/main/java/de/oppermann/pomutils/Main.java
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.beust.jcommander.JCommander;
+import com.beust.jcommander.ParameterException;
 
 import de.oppermann.pomutils.commands.CommandMain;
 import de.oppermann.pomutils.commands.CommandPomMergeDriver;
@@ -54,7 +55,12 @@ public class Main {
 		jc.addCommand("merge", mergeCommand);
 		jc.addCommand("replace", versionReplacerCommand);
 
-		jc.parse(args);
+		try {
+			jc.parse(args);
+		} catch (ParameterException e) {
+			System.err.println(e.getMessage());
+			return 1;
+		}
 
 		String logLevel = mainCommand.isDebug() ? "debug" : "error";
 		System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", logLevel);
@@ -77,9 +83,8 @@ public class Main {
 
 	private static int executePomMergeDriver(CommandPomMergeDriver mergeCommand) {
 		PomMergeDriver pomMergeDriver = new PomMergeDriver(mergeCommand.getBasePom(), mergeCommand.getOurPom(),
-		        mergeCommand.getTheirPom());
-		pomMergeDriver.adjustTheirPomVersion();
-		return pomMergeDriver.doGitMerge();
+		        mergeCommand.getTheirPom(), mergeCommand.getSelectionStrategy());
+		return pomMergeDriver.merge();
 	}
 
 	private static void executePomVersionReplacer(CommandPomVersionReplacer versionReplacerCommand) {

--- a/src/main/java/de/oppermann/pomutils/Main.java
+++ b/src/main/java/de/oppermann/pomutils/Main.java
@@ -61,7 +61,7 @@ public class Main {
 
 		logger = LoggerFactory.getLogger(Main.class);
 
-		logger.info("PomUtils {}", ManifestUtils.getManifestVersion());
+		logger.info("PomUtils version {}", ManifestUtils.getImplementationVersion());
 
 		if ("merge".equals(jc.getParsedCommand())) {
 			return executePomMergeDriver(mergeCommand);

--- a/src/main/java/de/oppermann/pomutils/Main.java
+++ b/src/main/java/de/oppermann/pomutils/Main.java
@@ -83,7 +83,7 @@ public class Main {
 
 	private static int executePomMergeDriver(CommandPomMergeDriver mergeCommand) {
 		PomMergeDriver pomMergeDriver = new PomMergeDriver(mergeCommand.getBasePom(), mergeCommand.getOurPom(),
-		        mergeCommand.getTheirPom(), mergeCommand.getSelectionStrategy());
+		        mergeCommand.getTheirPom(), mergeCommand.getSelectionStrategy().getSelector());
 		return pomMergeDriver.merge();
 	}
 

--- a/src/main/java/de/oppermann/pomutils/PomMergeDriver.java
+++ b/src/main/java/de/oppermann/pomutils/PomMergeDriver.java
@@ -26,9 +26,6 @@ import org.codehaus.plexus.util.IOUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import de.oppermann.pomutils.select.ConsoleVersionSelector;
-import de.oppermann.pomutils.select.PersistentVersionSelector;
-import de.oppermann.pomutils.select.SelectionStrategy;
 import de.oppermann.pomutils.select.VersionSelector;
 import de.oppermann.pomutils.util.POM;
 
@@ -45,22 +42,16 @@ public class PomMergeDriver {
 	private final POM basePom;
 	private final POM ourPom;
 	private final POM theirPom;
-	private final SelectionStrategy selectionStrategy;
 	
 	/**
-	 * The version selector to use when {@link #selectionStrategy} is {@link SelectionStrategy#PROMPT}.
+	 * The version selector to use resolve version conflicts.
 	 */
 	private final VersionSelector versionSelector;
 
-	public PomMergeDriver(String basePomFile, String ourPomFile, String theirPomFile, SelectionStrategy selectionStrategy) {
-		this(basePomFile, ourPomFile, theirPomFile, selectionStrategy, new PersistentVersionSelector(new ConsoleVersionSelector()));
-	}
-
-	public PomMergeDriver(String basePomFile, String ourPomFile, String theirPomFile, SelectionStrategy selectVersion, VersionSelector versionSelector) {
+	public PomMergeDriver(String basePomFile, String ourPomFile, String theirPomFile, VersionSelector versionSelector) {
 		basePom = new POM(basePomFile);
 		ourPom = new POM(ourPomFile);
 		theirPom = new POM(theirPomFile);
-		this.selectionStrategy = selectVersion;
 		this.versionSelector = versionSelector;
 	}
 
@@ -75,19 +66,7 @@ public class PomMergeDriver {
 		}
 		
 		if (ourVersion != null && theirVersion != null && !ourVersion.equals(theirVersion)) {
-			final String newVersion;
-			switch (this.selectionStrategy) {
-				case PROMPT:
-					newVersion = versionSelector.selectVersion(ourPom.getProjectIdentifier(), ourVersion, theirVersion);
-					break;
-				case THEIR:
-					newVersion = theirVersion;
-					break;
-				case OUR:
-				default:
-					newVersion = ourVersion;
-					break;
-			}
+			String newVersion = versionSelector.selectVersion(ourPom.getProjectIdentifier(), ourVersion, theirVersion);
 					
 			if (newVersion != null) {
 						

--- a/src/main/java/de/oppermann/pomutils/PomMergeDriver.java
+++ b/src/main/java/de/oppermann/pomutils/PomMergeDriver.java
@@ -19,10 +19,10 @@ package de.oppermann.pomutils;
  * under the License.
  */
 
-import java.io.BufferedReader;
+import java.io.BufferedInputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
 
+import org.codehaus.plexus.util.IOUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -90,16 +90,10 @@ public class PomMergeDriver {
 	}
 
 	private void consumeGitOutput(final Process p) throws IOException {
-		BufferedReader reader = new BufferedReader(new InputStreamReader(p.getInputStream()));
-
-		logger.debug("Git merge output:");
-		logger.debug("=====================================");
-		String line;
-		while ((line = reader.readLine()) != null) {
-			logger.debug(line);
-		}
-		reader.close();
-		logger.debug("=====================================");
+		
+		String output = IOUtil.toString(new BufferedInputStream(p.getInputStream(), 256));
+		
+		logger.debug("Git merge output:\n{}", output);
 	}
 
 }

--- a/src/main/java/de/oppermann/pomutils/commands/CommandPomMergeDriver.java
+++ b/src/main/java/de/oppermann/pomutils/commands/CommandPomMergeDriver.java
@@ -22,13 +22,15 @@ package de.oppermann.pomutils.commands;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 
+import de.oppermann.pomutils.select.SelectionStrategy;
+
 /**
  * 
  * @author Sven Oppermann <sven.oppermann@gmail.com>
  * 
  */
 
-@Parameters(separators = "=", commandDescription = "Used as merge driver in git. Updates the version of 'their pom.xml' with the version from 'our pom.xml' and does finally a normal 'git merge-file'")
+@Parameters(separators = "=", commandDescription = "Used as merge driver in git.  Updates the version of 'our' pom or 'their' pom (based on the value of --select), and then does a normal 'git merge-file'")
 public class CommandPomMergeDriver {
 
 	@Parameter(names = { "-b", "--base" }, description = "Base Pom", required = true)
@@ -39,6 +41,9 @@ public class CommandPomMergeDriver {
 
 	@Parameter(names = { "-t", "--their" }, description = "Their Pom", required = true)
 	private String theirPom;
+
+	@Parameter(names = { "-s", "--select" }, description = "Which version to select to resolve conflicts.  'our', 'their', or 'prompt'.  If 'prompt' is specified, then you will be prompted on the console to select a version.", required = false, converter = SelectionStrategyConverter.class)
+	private SelectionStrategy selectionStrategy = SelectionStrategy.OUR;
 
 	public String getBasePom() {
 		return basePom;
@@ -51,4 +56,9 @@ public class CommandPomMergeDriver {
 	public String getTheirPom() {
 		return theirPom;
 	}
+	
+	public SelectionStrategy getSelectionStrategy() {
+		return selectionStrategy;
+	}
+	
 }

--- a/src/main/java/de/oppermann/pomutils/commands/SelectionStrategyConverter.java
+++ b/src/main/java/de/oppermann/pomutils/commands/SelectionStrategyConverter.java
@@ -1,0 +1,23 @@
+package de.oppermann.pomutils.commands;
+
+import com.beust.jcommander.IStringConverter;
+import com.beust.jcommander.ParameterException;
+
+import de.oppermann.pomutils.select.SelectionStrategy;
+
+public class SelectionStrategyConverter implements IStringConverter<SelectionStrategy> {
+
+	@Override
+	public SelectionStrategy convert(String value) {
+		if (value == null) {
+			return SelectionStrategy.OUR;
+		}
+
+		try {
+			return SelectionStrategy.valueOf(value.toUpperCase());
+		} catch (IllegalArgumentException e) {
+			throw new ParameterException("--select must be one of 'ours', 'theirs', or 'prompt'");
+		}
+	}
+
+}

--- a/src/main/java/de/oppermann/pomutils/select/ConsoleVersionSelector.java
+++ b/src/main/java/de/oppermann/pomutils/select/ConsoleVersionSelector.java
@@ -1,0 +1,42 @@
+package de.oppermann.pomutils.select;
+
+import java.io.Console;
+
+/**
+ * A {@link VersionSelector} that prompts the user to select the version
+ * via the system console.
+ */
+public class ConsoleVersionSelector implements VersionSelector {
+
+	@Override
+	public String selectVersion(String projectIdentifier, String ourVersion, String theirVersion) {
+		Console console = System.console();
+		
+		console.printf("%nVersion conflict found in pom file for %s.%n%n", projectIdentifier);
+		
+		console.printf("Select the version to use to resolve the conflict:%n%n");
+		
+		console.printf("    1) %s (ours)%n", ourVersion);
+		console.printf("    2) %s (theirs)%n", theirVersion);
+		console.printf("    s) Skip and resolve later%n%n");
+		
+		console.printf("If the same conflict is found in other pom files in this merge%n");
+		console.printf("or any future merges that occur in the next 2 minutes),%n");
+		console.printf("your selection will be used for them as well.%n%n");
+		
+		do {
+			String selection = console.readLine("Preferred version? [1/2/s]: ");
+			
+			if (selection == null || selection.trim().equalsIgnoreCase("s")) {
+				console.printf("%n");
+				return null;
+			} else if (selection.trim().equalsIgnoreCase("1") || selection.trim().equals(ourVersion)) {
+				return ourVersion;
+			} else if (selection.trim().equalsIgnoreCase("2") || selection.trim().equals(theirVersion)) {
+				return theirVersion;
+			}
+			
+		} while (true); 
+	}
+
+}

--- a/src/main/java/de/oppermann/pomutils/select/OurVersionSelector.java
+++ b/src/main/java/de/oppermann/pomutils/select/OurVersionSelector.java
@@ -1,0 +1,13 @@
+package de.oppermann.pomutils.select;
+
+/**
+ * Always select 'our' version.
+ */
+public class OurVersionSelector implements VersionSelector {
+
+	@Override
+	public String selectVersion(String projectIdentifier, String ourVersion, String theirVersion) {
+		return ourVersion;
+	}
+
+}

--- a/src/main/java/de/oppermann/pomutils/select/PersistentVersionSelector.java
+++ b/src/main/java/de/oppermann/pomutils/select/PersistentVersionSelector.java
@@ -1,0 +1,178 @@
+package de.oppermann.pomutils.select;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Properties;
+
+import org.codehaus.plexus.util.IOUtil;
+
+/**
+ * Persists a selected version from a {@link #delegate} version selector to disk,
+ * and returns any valid previously selected version on future invocations.
+ * 
+ * This is used to store user selection between process invocations.
+ * The user's selection will be valid for 2 mins.
+ */
+public class PersistentVersionSelector implements VersionSelector {
+	
+	/**
+	 * Default file that is used to persist selection.
+	 * Found in the working directory.
+	 */
+	private static final File DEFAULT_PERSISTENT_FILE = new File(".pomVersionSelection");
+	
+	/**
+	 * Timeout in milliseconds after which the selection is considered timed out.
+	 * A user will have to make a new selection after this time has elapsed.
+	 * 
+	 * Since pomutils is invoked for every file, and there's no indication
+	 * of the first or last invocation, we rely on a timeout to clear
+	 * state between merge invocations.
+	 */
+	private static final long TIMEOUT = 2 * 60 * 1000; // 2 mins
+	
+	/**
+	 * File that is used to persist selection state.
+	 */
+	private final File persistentFile;
+
+	/**
+	 * Used to select the version if the persistent state does not exist or is no longer valid.
+	 */
+	private final VersionSelector delegate;
+	
+	/**
+	 * Represents the user's selection for a given conflict.
+	 */
+	private static class SelectionState {
+		private static final String PROPERTY_OUR_VERSION = "ourVersion";
+		private static final String PROPERTY_THEIR_VERSION = "theirVersion";
+		private static final String PROPERTY_SELECTED_VERSION = "selectedVersion";
+
+		private final String ourVersion;
+		private final String theirVersion;
+		/**
+		 * Version that the user selected, or null if the user chose to skip resolution.
+		 */
+		private final String selectedVersion;
+		
+		private SelectionState(
+				String ourVersion,
+				String theirVersion,
+				String selectedVersion) {
+			
+			super();
+			this.ourVersion = ourVersion;
+			this.theirVersion = theirVersion;
+			this.selectedVersion = selectedVersion;
+		}
+		
+		public static SelectionState fromProperties(Properties properties) {
+			String ourVersion = properties.getProperty(PROPERTY_OUR_VERSION);
+			String theirVersion = properties.getProperty(PROPERTY_THEIR_VERSION);
+			String selectedVersion = properties.getProperty(PROPERTY_SELECTED_VERSION);
+			
+			if (ourVersion == null || theirVersion == null) {
+				return null;
+			}
+			return new SelectionState(ourVersion, theirVersion, selectedVersion);
+		}
+		
+		public Properties toProperties() {
+			Properties properties = new Properties();
+			properties.setProperty(PROPERTY_OUR_VERSION, ourVersion);
+			properties.setProperty(PROPERTY_THEIR_VERSION, theirVersion);
+			if (selectedVersion != null) {
+				properties.setProperty(PROPERTY_SELECTED_VERSION, selectedVersion);
+			}
+			return properties;
+		}
+		
+		public String getSelectedVersion() {
+			return selectedVersion;
+		}
+		
+		public boolean isValidFor(String ourVersion, String theirVersion) {
+			return this.ourVersion.equals(ourVersion)
+					&& this.theirVersion.equals(theirVersion);
+		}
+	}
+	
+	public PersistentVersionSelector(VersionSelector delegate) {
+		this(delegate, DEFAULT_PERSISTENT_FILE);
+	}
+
+	public PersistentVersionSelector(VersionSelector delegate, File persistentFile) {
+		super();
+		this.delegate = delegate;
+		this.persistentFile = persistentFile;
+	}
+
+	@Override
+	public String selectVersion(String projectIdentifier, String ourVersion, String theirVersion) {
+		try {
+			SelectionState selectionState = readState();
+			
+			String selectedVersion;
+			if (selectionState != null && selectionState.isValidFor(ourVersion, theirVersion)) {
+				selectedVersion = selectionState.getSelectedVersion();
+			} else {
+				selectedVersion = delegate.selectVersion(projectIdentifier, ourVersion, theirVersion);
+				writeState(new SelectionState(ourVersion, theirVersion, selectedVersion));
+			}
+			return selectedVersion;
+		} catch (IOException e) {
+			return null;
+		}
+	}
+
+	/**
+	 * Reads the selection state from {@link #persistentFile}.
+	 */
+	private SelectionState readState() throws IOException {
+		if (!persistentFile.canRead()) {
+			return null;
+		}
+		
+		if (persistentFile.lastModified() < System.currentTimeMillis() - TIMEOUT) {
+			return null;
+		}
+		
+		FileReader reader = null; 
+		
+		try {
+			reader = new FileReader(persistentFile);
+			Properties properties = new Properties();
+			properties.load(reader);
+			
+			return SelectionState.fromProperties(properties);
+		} finally {
+			IOUtil.close(reader);
+		}
+	}
+	
+	/**
+	 * Writes the selection state to {@link #persistentFile}.
+	 */
+	private void writeState(SelectionState selectionState) throws IOException {
+		FileWriter writer = null; 
+		
+		try {
+			writer = new FileWriter(persistentFile);
+			Properties properties = selectionState.toProperties();
+			properties.store(
+					writer,
+					String.format("Used by the 'pomutils' merge driver to store version selections%n"
+						+ "within the same invocation of git merge%n"
+						+ "(to avoid repeatedly prompting the user to select a version).%n"
+						+ "Selected versions will only be reused for 2 minutes.%n"
+						+ "It is safe to delete this file between git merge invocations%n"
+						+ "(which will cause the user to be prompted again).%n"));
+		} finally {
+			IOUtil.close(writer);
+		}
+	}
+	
+}

--- a/src/main/java/de/oppermann/pomutils/select/SelectionStrategy.java
+++ b/src/main/java/de/oppermann/pomutils/select/SelectionStrategy.java
@@ -8,20 +8,32 @@ public enum SelectionStrategy {
 	/**
 	 * Always select 'our' version (the default). 
 	 */
-	OUR,
+	OUR(new OurVersionSelector()),
+	
 	/**
 	 * Always select 'their' version. 
 	 */
-	THEIR,
+	THEIR(new TheirVersionSelector()),
+	
 	/**
 	 * Prompt the user on the console for them to select the version. 
 	 */
-	PROMPT;
+	PROMPT(new PersistentVersionSelector(new ConsoleVersionSelector()));
 	
+	private final VersionSelector selector;
+	
+	private SelectionStrategy(VersionSelector selector) {
+		this.selector = selector;
+	}
+
 	/*
 	 * Overridden so that the proper string appears in --help output. 
 	 */
 	public String toString() {
 		return name().toLowerCase();
+	}
+	
+	public VersionSelector getSelector() {
+		return selector;
 	}
 }

--- a/src/main/java/de/oppermann/pomutils/select/SelectionStrategy.java
+++ b/src/main/java/de/oppermann/pomutils/select/SelectionStrategy.java
@@ -1,0 +1,27 @@
+package de.oppermann.pomutils.select;
+
+/**
+ * Strategy to use to select a version to resolve conflicts.
+ */
+public enum SelectionStrategy {
+	
+	/**
+	 * Always select 'our' version (the default). 
+	 */
+	OUR,
+	/**
+	 * Always select 'their' version. 
+	 */
+	THEIR,
+	/**
+	 * Prompt the user on the console for them to select the version. 
+	 */
+	PROMPT;
+	
+	/*
+	 * Overridden so that the proper string appears in --help output. 
+	 */
+	public String toString() {
+		return name().toLowerCase();
+	}
+}

--- a/src/main/java/de/oppermann/pomutils/select/TheirVersionSelector.java
+++ b/src/main/java/de/oppermann/pomutils/select/TheirVersionSelector.java
@@ -1,0 +1,13 @@
+package de.oppermann.pomutils.select;
+
+/**
+ * Always select 'their' version.
+ */
+public class TheirVersionSelector implements VersionSelector {
+
+	@Override
+	public String selectVersion(String projectIdentifier, String ourVersion, String theirVersion) {
+		return theirVersion;
+	}
+
+}

--- a/src/main/java/de/oppermann/pomutils/select/VersionSelector.java
+++ b/src/main/java/de/oppermann/pomutils/select/VersionSelector.java
@@ -1,0 +1,9 @@
+package de.oppermann.pomutils.select;
+
+/**
+ * Callback used to select a version.
+ */
+public interface VersionSelector {
+
+    String selectVersion(String projectIdentifier, String ourVersion, String theirVersion);
+}

--- a/src/main/java/de/oppermann/pomutils/select/VersionSelector.java
+++ b/src/main/java/de/oppermann/pomutils/select/VersionSelector.java
@@ -5,5 +5,14 @@ package de.oppermann.pomutils.select;
  */
 public interface VersionSelector {
 
-    String selectVersion(String projectIdentifier, String ourVersion, String theirVersion);
+	/**
+	 * Selects the version to use to resolve a version conflict.
+	 * 
+	 * @param projectIdentifier Human-readable string used to identify the pom project.
+	 * @param ourVersion version of 'our' pom file
+	 * @param theirVersion version of 'their' pom file
+	 * @return the version to use to resolve the conflict. (either ourVersion, theirVersion, or null)
+	 *         if null, then the conflict will not be resolved. 
+	 */
+	String selectVersion(String projectIdentifier, String ourVersion, String theirVersion);
 }

--- a/src/main/java/de/oppermann/pomutils/util/ManifestUtils.java
+++ b/src/main/java/de/oppermann/pomutils/util/ManifestUtils.java
@@ -19,11 +19,6 @@ package de.oppermann.pomutils.util;
  * under the License.
  */
 
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.jar.Attributes;
-import java.util.jar.Manifest;
 
 /**
  * 
@@ -33,27 +28,11 @@ import java.util.jar.Manifest;
 
 public class ManifestUtils {
 
-	public static String getManifestVersion() {
-		Class<ManifestUtils> clazz = ManifestUtils.class;
-
-		String className = clazz.getSimpleName() + ".class";
-		String classPath = clazz.getResource(className).toString();
-
-		if (!classPath.startsWith("jar")) {
-			return "not a jar";
-		}
-		String manifestPath = classPath.substring(0, classPath.lastIndexOf("!") + 1) + "/META-INF/MANIFEST.MF";
-		Manifest manifest;
-
-		try {
-			manifest = new Manifest(new URL(manifestPath).openStream());
-		} catch (MalformedURLException e) {
-			throw new RuntimeException(e);
-		} catch (IOException e) {
-			throw new RuntimeException(e);
-		}
-		Attributes attr = manifest.getMainAttributes();
-		return attr.getValue("Manifest-Version");
+	public static String getImplementationVersion() {
+		String version = ManifestUtils.class.getPackage().getImplementationVersion();
+		return (version == null)
+			? "Unknown (not a jar)"
+			: version;
 	}
 
 }

--- a/src/main/java/de/oppermann/pomutils/util/POM.java
+++ b/src/main/java/de/oppermann/pomutils/util/POM.java
@@ -26,6 +26,7 @@ import javax.xml.stream.FactoryConfigurationError;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 
+import org.apache.maven.model.Model;
 import org.apache.maven.model.Parent;
 import org.codehaus.mojo.versions.api.PomHelper;
 import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
@@ -78,11 +79,10 @@ public class POM {
 		try {
 			StringBuilder input = new StringBuilder(FileUtils.fileRead(pomFile));
 			pom = new ModifiedPomXMLEventReader(input, XML_INPUT_FACTORY);
-			projectVersion = PomHelper.getProjectVersion(pom);
-			
-			Parent parent = PomHelper.getRawModel(pom).getParent();
-			parentVersion = parent != null
-					? parent.getVersion()
+			Model model = PomHelper.getRawModel(pom);
+			projectVersion = model.getVersion();
+			parentVersion = model.getParent() != null
+					? model.getParent().getVersion()
 					: null;
 		} catch (IOException e) {
 			throw new RuntimeException(e);

--- a/src/test/java/de/oppermann/pomutils/PomMergeDriverTest.java
+++ b/src/test/java/de/oppermann/pomutils/PomMergeDriverTest.java
@@ -29,6 +29,8 @@ import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
 
 import com.ctc.wstx.stax.WstxInputFactory;
 
+import de.oppermann.pomutils.select.SelectionStrategy;
+import de.oppermann.pomutils.select.VersionSelector;
 import de.oppermann.pomutils.util.POM;
 
 /**
@@ -54,17 +56,66 @@ public class PomMergeDriverTest extends TestCase {
 		String ourPomFile = "target/testresources/merge/autoMergeSucceded/our.pom.xml";
 		String theirPomFile = "target/testresources/merge/autoMergeSucceded/their.pom.xml";
 
-		PomMergeDriver pomMergeDriver = new PomMergeDriver(basePomFile, ourPomFile, theirPomFile);
-		pomMergeDriver.adjustTheirPomVersion();
-		int mergeReturnValue = pomMergeDriver.doGitMerge();
+		PomMergeDriver pomMergeDriver = new PomMergeDriver(basePomFile, ourPomFile, theirPomFile, SelectionStrategy.OUR);
+		int mergeReturnValue = pomMergeDriver.merge();
 
 		assertTrue("merge succeeded", mergeReturnValue == 0);
 		
 		POM theirPom = new POM(theirPomFile);
 		POM ourPom = new POM(ourPomFile);
 
-		assertEquals("same version now", ourPom.getProjectVersion(), theirPom.getProjectVersion());
+		assertEquals("our", ourPom.getProjectVersion());
+		assertEquals("our", theirPom.getProjectVersion());
 		
+		String theirDependecyVersoin = PomHelper.getRawModel(new File(theirPomFile)).getDependencies().get(0).getVersion();
+		String ourDependencyVersion = PomHelper.getRawModel(new File(ourPomFile)).getDependencies().get(0).getVersion();
+		
+		assertEquals("dependency version change merged", theirDependecyVersoin, ourDependencyVersion);
+	}
+
+	public void testAutoMergeSucceded_their() throws Exception {
+		String basePomFile = "target/testresources/merge/autoMergeSucceded_their/base.pom.xml";
+		String ourPomFile = "target/testresources/merge/autoMergeSucceded_their/our.pom.xml";
+		String theirPomFile = "target/testresources/merge/autoMergeSucceded_their/their.pom.xml";
+
+		PomMergeDriver pomMergeDriver = new PomMergeDriver(basePomFile, ourPomFile, theirPomFile, SelectionStrategy.THEIR);
+		int mergeReturnValue = pomMergeDriver.merge();
+
+		assertTrue("merge succeeded", mergeReturnValue == 0);
+		
+		POM theirPom = new POM(theirPomFile);
+		POM ourPom = new POM(ourPomFile);
+
+		assertEquals("their", ourPom.getProjectVersion());
+		assertEquals("their", theirPom.getProjectVersion());
+		
+		String theirDependecyVersoin = PomHelper.getRawModel(new File(theirPomFile)).getDependencies().get(0).getVersion();
+		String ourDependencyVersion = PomHelper.getRawModel(new File(ourPomFile)).getDependencies().get(0).getVersion();
+		
+		assertEquals("dependency version change merged", theirDependecyVersoin, ourDependencyVersion);
+	}
+
+	public void testAutoMergeSucceded_prompt() throws Exception {
+		String basePomFile = "target/testresources/merge/autoMergeSucceded_prompt/base.pom.xml";
+		String ourPomFile = "target/testresources/merge/autoMergeSucceded_prompt/our.pom.xml";
+		String theirPomFile = "target/testresources/merge/autoMergeSucceded_prompt/their.pom.xml";
+
+		PomMergeDriver pomMergeDriver = new PomMergeDriver(basePomFile, ourPomFile, theirPomFile, SelectionStrategy.PROMPT, new VersionSelector() {
+			
+			@Override
+			public String selectVersion(String projectIdentifier, String ourVersion, String theirVersion) {
+				return theirVersion;
+			}
+		});
+		int mergeReturnValue = pomMergeDriver.merge();
+
+		assertTrue("merge succeeded", mergeReturnValue == 0);
+		
+		POM theirPom = new POM(theirPomFile);
+		POM ourPom = new POM(ourPomFile);
+
+		assertEquals("their", ourPom.getParentVersion());
+		assertEquals("their", theirPom.getParentVersion());
 		
 		String theirDependecyVersoin = PomHelper.getRawModel(new File(theirPomFile)).getDependencies().get(0).getVersion();
 		String ourDependencyVersion = PomHelper.getRawModel(new File(ourPomFile)).getDependencies().get(0).getVersion();
@@ -77,9 +128,8 @@ public class PomMergeDriverTest extends TestCase {
 		String ourPomFile = "target/testresources/merge/autoMergeFailed/our.pom.xml";
 		String theirPomFile = "target/testresources/merge/autoMergeFailed/their.pom.xml";
 
-		PomMergeDriver pomMergeDriver = new PomMergeDriver(basePomFile, ourPomFile, theirPomFile);
-		pomMergeDriver.adjustTheirPomVersion();
-		int mergeReturnValue = pomMergeDriver.doGitMerge();
+		PomMergeDriver pomMergeDriver = new PomMergeDriver(basePomFile, ourPomFile, theirPomFile, SelectionStrategy.OUR);
+		int mergeReturnValue = pomMergeDriver.merge();
 
 		assertTrue("merge conflict", mergeReturnValue == 1);
 

--- a/src/test/java/de/oppermann/pomutils/PomMergeDriverTest.java
+++ b/src/test/java/de/oppermann/pomutils/PomMergeDriverTest.java
@@ -25,6 +25,9 @@ import junit.framework.TestCase;
 
 import org.apache.commons.io.FileUtils;
 import org.codehaus.mojo.versions.api.PomHelper;
+import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
+
+import com.ctc.wstx.stax.WstxInputFactory;
 
 import de.oppermann.pomutils.util.POM;
 
@@ -81,8 +84,10 @@ public class PomMergeDriverTest extends TestCase {
 		assertTrue("merge conflict", mergeReturnValue == 1);
 
 		POM theirPom = new POM(theirPomFile);
-		POM ourPom = new POM(ourPomFile);
-
-		assertEquals("same version now", ourPom.getProjectVersion(), theirPom.getProjectVersion());
+		
+		StringBuilder ourPomString = new StringBuilder(FileUtils.readFileToString(new File(ourPomFile)));
+		String ourProjectVersion = PomHelper.getProjectVersion(new ModifiedPomXMLEventReader(ourPomString, new WstxInputFactory()));
+		
+		assertEquals("same version now", ourProjectVersion, theirPom.getProjectVersion());
 	}
 }

--- a/src/test/java/de/oppermann/pomutils/PomMergeDriverTest.java
+++ b/src/test/java/de/oppermann/pomutils/PomMergeDriverTest.java
@@ -56,7 +56,7 @@ public class PomMergeDriverTest extends TestCase {
 		String ourPomFile = "target/testresources/merge/autoMergeSucceded/our.pom.xml";
 		String theirPomFile = "target/testresources/merge/autoMergeSucceded/their.pom.xml";
 
-		PomMergeDriver pomMergeDriver = new PomMergeDriver(basePomFile, ourPomFile, theirPomFile, SelectionStrategy.OUR);
+		PomMergeDriver pomMergeDriver = new PomMergeDriver(basePomFile, ourPomFile, theirPomFile, SelectionStrategy.OUR.getSelector());
 		int mergeReturnValue = pomMergeDriver.merge();
 
 		assertTrue("merge succeeded", mergeReturnValue == 0);
@@ -78,7 +78,7 @@ public class PomMergeDriverTest extends TestCase {
 		String ourPomFile = "target/testresources/merge/autoMergeSucceded_their/our.pom.xml";
 		String theirPomFile = "target/testresources/merge/autoMergeSucceded_their/their.pom.xml";
 
-		PomMergeDriver pomMergeDriver = new PomMergeDriver(basePomFile, ourPomFile, theirPomFile, SelectionStrategy.THEIR);
+		PomMergeDriver pomMergeDriver = new PomMergeDriver(basePomFile, ourPomFile, theirPomFile, SelectionStrategy.THEIR.getSelector());
 		int mergeReturnValue = pomMergeDriver.merge();
 
 		assertTrue("merge succeeded", mergeReturnValue == 0);
@@ -100,7 +100,7 @@ public class PomMergeDriverTest extends TestCase {
 		String ourPomFile = "target/testresources/merge/autoMergeSucceded_prompt/our.pom.xml";
 		String theirPomFile = "target/testresources/merge/autoMergeSucceded_prompt/their.pom.xml";
 
-		PomMergeDriver pomMergeDriver = new PomMergeDriver(basePomFile, ourPomFile, theirPomFile, SelectionStrategy.PROMPT, new VersionSelector() {
+		PomMergeDriver pomMergeDriver = new PomMergeDriver(basePomFile, ourPomFile, theirPomFile, new VersionSelector() {
 			
 			@Override
 			public String selectVersion(String projectIdentifier, String ourVersion, String theirVersion) {
@@ -128,7 +128,7 @@ public class PomMergeDriverTest extends TestCase {
 		String ourPomFile = "target/testresources/merge/autoMergeFailed/our.pom.xml";
 		String theirPomFile = "target/testresources/merge/autoMergeFailed/their.pom.xml";
 
-		PomMergeDriver pomMergeDriver = new PomMergeDriver(basePomFile, ourPomFile, theirPomFile, SelectionStrategy.OUR);
+		PomMergeDriver pomMergeDriver = new PomMergeDriver(basePomFile, ourPomFile, theirPomFile, SelectionStrategy.OUR.getSelector());
 		int mergeReturnValue = pomMergeDriver.merge();
 
 		assertTrue("merge conflict", mergeReturnValue == 1);

--- a/src/test/java/de/oppermann/pomutils/select/PersistentVersionSelectorTest.java
+++ b/src/test/java/de/oppermann/pomutils/select/PersistentVersionSelectorTest.java
@@ -1,0 +1,82 @@
+package de.oppermann.pomutils.select;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+public class PersistentVersionSelectorTest {
+
+	@Rule
+	public TemporaryFolder tempFolder = new TemporaryFolder();
+	
+	private File tempFile;
+	
+	@Rule
+	public MockitoRule mockitoRule = MockitoJUnit.rule();
+	
+	@Mock
+	private VersionSelector delegateSelector;
+
+	private PersistentVersionSelector persistentSelector;
+	
+	@Before
+	public void setup() throws IOException {
+		tempFile = tempFolder.newFile();
+		persistentSelector = new PersistentVersionSelector(delegateSelector, tempFile);
+	}
+	
+	
+	@Test
+	public void testFileDoesNotExist() throws IOException {
+		tempFile.delete();
+		when(delegateSelector.selectVersion("id", "our", "their")).thenReturn("our");
+		assertEquals("our", persistentSelector.selectVersion("id", "our", "their"));
+		
+		assertEquals("our", persistentSelector.selectVersion("id", "our", "their"));
+		
+		verify(delegateSelector).selectVersion("id", "our", "their");
+	}
+	
+	@Test
+	public void testSkip() throws IOException {
+		assertNull(persistentSelector.selectVersion("id", "our", "their"));
+		
+		assertNull(persistentSelector.selectVersion("id", "our", "their"));
+		
+		verify(delegateSelector).selectVersion("id", "our", "their");
+	}
+	
+	@Test
+	public void testSelect() throws IOException {
+		when(delegateSelector.selectVersion("id", "our", "their")).thenReturn("their");
+		assertEquals("their", persistentSelector.selectVersion("id", "our", "their"));
+		
+		assertEquals("their", persistentSelector.selectVersion("id", "our", "their"));
+		
+		verify(delegateSelector).selectVersion("id", "our", "their");
+	}
+	
+	@Test
+	public void testNotValid() throws IOException {
+		when(delegateSelector.selectVersion("id", "our", "their")).thenReturn("their");
+		when(delegateSelector.selectVersion("id", "our2", "their2")).thenReturn("our2");
+		
+		assertEquals("their", persistentSelector.selectVersion("id", "our", "their"));
+		
+		assertEquals("our2", persistentSelector.selectVersion("id", "our2", "their2"));
+		
+		verify(delegateSelector).selectVersion("id", "our", "their");
+		verify(delegateSelector).selectVersion("id", "our2", "their2");
+	}
+}

--- a/src/test/resources/merge/autoMergeSucceded_prompt/base.pom.xml
+++ b/src/test/resources/merge/autoMergeSucceded_prompt/base.pom.xml
@@ -1,0 +1,16 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+	  <groupId>de.oppermann.git.pommergedriver</groupId>
+	  <artifactId>pommergedriver</artifactId>
+	  <version>base</version>
+  </parent>
+  <dependencies>
+  	<dependency>
+  		<groupId>org.codehaus.mojo</groupId>
+  		<artifactId>versions-maven-plugin</artifactId>
+  		<version>2.1</version>
+  		<type>maven-plugin</type>
+  	</dependency>
+  </dependencies>
+</project>

--- a/src/test/resources/merge/autoMergeSucceded_prompt/our.pom.xml
+++ b/src/test/resources/merge/autoMergeSucceded_prompt/our.pom.xml
@@ -1,0 +1,16 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+      <groupId>de.oppermann.git.pommergedriver</groupId>
+      <artifactId>pommergedriver</artifactId>
+      <version>our</version>
+  </parent>
+  <dependencies>
+  	<dependency>
+  		<groupId>org.codehaus.mojo</groupId>
+  		<artifactId>versions-maven-plugin</artifactId>
+  		<version>2.1</version>
+  		<type>maven-plugin</type>
+  	</dependency>
+  </dependencies>
+</project>

--- a/src/test/resources/merge/autoMergeSucceded_prompt/their.pom.xml
+++ b/src/test/resources/merge/autoMergeSucceded_prompt/their.pom.xml
@@ -1,0 +1,16 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+      <groupId>de.oppermann.git.pommergedriver</groupId>
+      <artifactId>pommergedriver</artifactId>
+      <version>their</version>
+  </parent>
+  <dependencies>
+  	<dependency>
+  		<groupId>org.codehaus.mojo</groupId>
+  		<artifactId>versions-maven-plugin</artifactId>
+  		<version>2.5</version>
+  		<type>maven-plugin</type>
+  	</dependency>
+  </dependencies>
+</project>

--- a/src/test/resources/merge/autoMergeSucceded_their/base.pom.xml
+++ b/src/test/resources/merge/autoMergeSucceded_their/base.pom.xml
@@ -1,0 +1,14 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>de.oppermann.git.pommergedriver</groupId>
+  <artifactId>pommergedriver</artifactId>
+  <version>base</version>
+  <dependencies>
+  	<dependency>
+  		<groupId>org.codehaus.mojo</groupId>
+  		<artifactId>versions-maven-plugin</artifactId>
+  		<version>2.1</version>
+  		<type>maven-plugin</type>
+  	</dependency>
+  </dependencies>
+</project>

--- a/src/test/resources/merge/autoMergeSucceded_their/our.pom.xml
+++ b/src/test/resources/merge/autoMergeSucceded_their/our.pom.xml
@@ -1,0 +1,14 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>de.oppermann.git.pommergedriver</groupId>
+  <artifactId>pommergedriver</artifactId>
+  <version>our</version>
+  <dependencies>
+  	<dependency>
+  		<groupId>org.codehaus.mojo</groupId>
+  		<artifactId>versions-maven-plugin</artifactId>
+  		<version>2.1</version>
+  		<type>maven-plugin</type>
+  	</dependency>
+  </dependencies>
+</project>

--- a/src/test/resources/merge/autoMergeSucceded_their/their.pom.xml
+++ b/src/test/resources/merge/autoMergeSucceded_their/their.pom.xml
@@ -1,0 +1,14 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>de.oppermann.git.pommergedriver</groupId>
+  <artifactId>pommergedriver</artifactId>
+  <version>their</version>
+  <dependencies>
+  	<dependency>
+  		<groupId>org.codehaus.mojo</groupId>
+  		<artifactId>versions-maven-plugin</artifactId>
+  		<version>2.5</version>
+  		<type>maven-plugin</type>
+  	</dependency>
+  </dependencies>
+</project>


### PR DESCRIPTION
The main feature in this pull request is the ability to specify a version selection strategy for resolving version merge conflicts.

Previously, _our_ version was always selected to resolve merge conflicts.  This is still the default.

This pull request allows selection of _our_, _their_, or _prompt_.

If _their_ is specified, then _their_ version will be selected.

If _prompt_ is specified, then the user will be shown the differing versions on the console, and allowed to select the version to use for each merge.  The user's selection is used throughout the duration of a single merge so they don't get repeatedly prompted.

Other misc cleanup:
- Removed unused dependencies.  This reduces the jar file size (1.7MB instead of 7MB) and improves performance a tiny bit
- Fixed the pomutils version number displayed when debug output was turned on.  It was using the manifest version, which is always 1.0.  I switched it to use the implementation version, which will be the version of pomutils
- Performance improvements (simplify reads/writes, etc).  Profiled with yourkit profiler.  Improves merge performance 10-20%
